### PR TITLE
Fix: deprecated env var setting

### DIFF
--- a/.github/workflows/sonarqube-frontend.yml
+++ b/.github/workflows/sonarqube-frontend.yml
@@ -34,7 +34,7 @@ jobs:
           install-dependencies: true
         id: setup-chrome
       - run: |
-          echo "::set-env name=CHROME_BIN::${{steps.setup-chrome.outputs.chrome-path}}"
+          echo "CHROME_BIN=${{steps.setup-chrome.outputs.chrome-path}}" >> $GITHUB_ENV
 
       - name: Install dependencies
         working-directory: frontend


### PR DESCRIPTION
Fix environment variable setting for Chrome binary in SonarQube workflow used deprecated methods