### PR TITLE
Restored NotNull Constraint

### DIFF
--- a/backend/.idea/workspace.xml
+++ b/backend/.idea/workspace.xml
@@ -6,10 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="f098cd5c-a01e-4169-b695-26bc132bef5a" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/hs_esslingen/insy/controller/InventoriesController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/hs_esslingen/insy/controller/InventoriesController.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/hs_esslingen/insy/model/Comments.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/hs_esslingen/insy/model/Comments.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/hs_esslingen/insy/model/Inventories.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/hs_esslingen/insy/model/Inventories.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/hs_esslingen/insy/model/Users.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/hs_esslingen/insy/model/Users.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/com/hs_esslingen/insy/services/CSVService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/hs_esslingen/insy/services/CSVService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/resources/application.properties" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application.properties" afterDir="false" />
     </list>
@@ -126,7 +124,7 @@
       <workItem from="1747473320034" duration="12000" />
       <workItem from="1747474783942" duration="827000" />
       <workItem from="1747475926726" duration="154000" />
-      <workItem from="1747502221925" duration="33298000" />
+      <workItem from="1747502221925" duration="36275000" />
     </task>
     <servers />
   </component>

--- a/backend/src/main/java/com/hs_esslingen/insy/model/Comments.java
+++ b/backend/src/main/java/com/hs_esslingen/insy/model/Comments.java
@@ -21,7 +21,7 @@ public class Comments {
     private Inventories inventories;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "author_user_id", referencedColumnName = "id", nullable = true)
+    @JoinColumn(name = "author_user_id", referencedColumnName = "id", nullable = false)
     @JsonBackReference
     private Users author;
 

--- a/backend/src/main/java/com/hs_esslingen/insy/model/Inventories.java
+++ b/backend/src/main/java/com/hs_esslingen/insy/model/Inventories.java
@@ -24,24 +24,24 @@ public class Inventories {
     private Integer id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "cost_centers_id", nullable = true)
+    @JoinColumn(name = "cost_centers_id", nullable = true) // true, since costCenters can not be parsed yet
     @JsonIgnore
     private CostCenters costCenters;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "users_id", nullable = true)
+    @JoinColumn(name = "users_id", nullable = false)
     @JsonIgnore
     private Users user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "companies_id", nullable = true)
+    @JoinColumn(name = "companies_id", nullable = false)
     @JsonIgnore
     private Companies company;
 
     @Column(nullable = false)
     private String description;
 
-    @Column(name = "serial_number", nullable = true)
+    @Column(name = "serial_number", nullable = false)
     private String serialNumber;
 
     @Column(name = "is_deinventoried", nullable = false)
@@ -50,7 +50,7 @@ public class Inventories {
     @Column(nullable = false)
     private BigDecimal price;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String location;
 
     @Column(name = "created_at", nullable = false)

--- a/backend/src/main/java/com/hs_esslingen/insy/services/CSVService.java
+++ b/backend/src/main/java/com/hs_esslingen/insy/services/CSVService.java
@@ -39,6 +39,7 @@ public class CSVService {
     }
 
 
+    @Transactional
     public void importCSVImproved(MultipartFile file) throws IOException {
         List<InventoryItem> objects = readCSVFile(file);
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,7 +17,7 @@ spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.format_sql = true
 spring.datasource.hikari.auto-commit=false
-spring.jpa.properties.hibernate.jdbc.batch_size=30
+spring.jpa.properties.hibernate.jdbc.batch_size=1000
 
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
## Pull Request Overview

This PR restores and tightens several NOT NULL constraints on inventory and comment entities, increases the JDBC batch size for Hibernate, and marks a CSV import method as transactional.

- Increased Hibernate JDBC batch size to improve write batching.
- Adjusted nullability on entity relationships and fields to enforce stricter data integrity.
- Added `@Transactional` to the CSV import method to ensure atomic imports.

### Reviewed Changes

Copilot reviewed 4 out of 5 changed files in this pull request and generated 1 comment.

| File                                                        | Description                                                      |
| ----------------------------------------------------------- | ---------------------------------------------------------------- |
| backend/src/main/resources/application.properties           | Increased Hibernate `jdbc.batch_size` from 30 to 1000            |
| backend/src/main/java/com/hs_esslingen/insy/services/CSVService.java | Added `@Transactional` to the `importCSVImproved` method         |
| backend/src/main/java/com/hs_esslingen/insy/model/Inventories.java    | Updated `@JoinColumn` and `@Column` nullability on several fields|
| backend/src/main/java/com/hs_esslingen/insy/model/Comments.java       | Made `author_user_id` join column non-nullable                  |

<details>
<summary>Files not reviewed (1)</summary>

* **backend/.idea/workspace.xml**: Language not supported
</details>

<details>
<summary>Comments suppressed due to low confidence (4)</summary>

**backend/src/main/java/com/hs_esslingen/insy/services/CSVService.java:43**
* The `importCSVImproved` method is now transactional; add or update integration tests to verify that failures within this method correctly roll back database changes.
```
public void importCSVImproved(MultipartFile file) throws IOException {
```
**backend/src/main/resources/application.properties:20**
* Increasing the batch size from 30 to 1000 may lead to high memory consumption or transaction timeouts for large imports; consider profiling with realistic data volumes or selecting a more moderate batch size.
```
spring.jpa.properties.hibernate.jdbc.batch_size=1000
```
**backend/src/main/java/com/hs_esslingen/insy/model/Inventories.java:44**
* Making `serial_number` non-nullable is a breaking schema change; ensure there's a database migration and that existing records comply with this constraint before deployment.
```
@Column(name = "serial_number", nullable = false)
```
**backend/src/main/java/com/hs_esslingen/insy/model/Comments.java:24**
* Setting `author_user_id` to non-nullable can break existing data; verify that all comments have an author and include a migration script to backfill or clean up orphaned records.
```
@JoinColumn(name = "author_user_id", referencedColumnName = "id", nullable = false)
```
</details>

