### PR TITLE
feat: Add filter reset to inventory page

### DIFF
--- a/frontend/src/app/components/range-slider/range-slider.component.ts
+++ b/frontend/src/app/components/range-slider/range-slider.component.ts
@@ -1,8 +1,8 @@
-import {Component, effect, input, signal} from '@angular/core';
-import {MatSlider, MatSliderRangeThumb} from '@angular/material/slider';
-import {MatFormField} from '@angular/material/form-field';
-import {MatInput, MatLabel} from '@angular/material/input';
-import {FormControl, FormsModule, ReactiveFormsModule} from '@angular/forms';
+import { Component, effect, input, signal } from '@angular/core';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatFormField } from '@angular/material/form-field';
+import { MatInput, MatLabel } from '@angular/material/input';
+import { MatSlider, MatSliderRangeThumb } from '@angular/material/slider';
 
 @Component({
   selector: 'app-range-slider',
@@ -40,5 +40,12 @@ export class RangeSliderComponent {
 
   leftValue = signal<number>(0);
   rightValue = signal<number>(1000);
+
+  resetSlider() {
+    this.leftValue.set(this.minValue());
+    this.rightValue.set(this.maxValue());
+    this.controlMin().setValue(this.minValue());
+    this.controlMax().setValue(this.maxValue());
+  }
 
 }

--- a/frontend/src/app/pages/inventory/inventory.component.html
+++ b/frontend/src/app/pages/inventory/inventory.component.html
@@ -3,79 +3,82 @@
   <app-card title="Filter" class="grow min-w-96 max-w-md">
     <div card-content class="w-full">
       <!-- Filter Action Buttons -->
-      <div class="example-action-buttons">
-        <button mat-button (click)="openAllAccordion()">Alles ausklappen</button>
-        <button mat-button (click)="closeAllAccordions()">Alles einklappen</button>
+      <div class="flex justify-between mb-4">
+        <div class="flex items-center gap-2">
+          <button mat-button (click)="openAllAccordion()">Alles ausklappen</button>
+          <button mat-button (click)="closeAllAccordions()">Alles einklappen</button>
+        </div>
+        <button mat-button color="warn" (click)="resetFilters()">Reset</button>
       </div>
 
       <!-- Accordion Sections -->
       <app-accordion title="Inventarnummer">
         <div expansion-panel-content>
           <app-range-slider [minValue]="minAndMaxId.minId" [maxValue]="minAndMaxId.maxId"
-                            [controlMin]="$any(inventoryForm).get('minId')" [controlMax]="$any(inventoryForm).get('maxId')" />
+            [controlMin]="$any(inventoryForm).get('minId')" [controlMax]="$any(inventoryForm).get('maxId')" />
         </div>
       </app-accordion>
 
       <app-accordion title="Zeitraum">
         <div class="min-h-fit" expansion-panel-content>
           <app-datepicker class="min-h-fit" [controlMin]="$any(inventoryForm).get('createdAfter')"
-                          [controlMax]="$any(inventoryForm).get('createdBefore')" />
+            [controlMax]="$any(inventoryForm).get('createdBefore')" />
         </div>
       </app-accordion>
 
       <app-accordion title="Firma">
         <div expansion-panel-content>
           <app-chip-v2 placeholder="Firma hinzufügen" heading="Firma" [options]="companies"
-                       [control]="$any(inventoryForm).get('company')" />
+            [control]="$any(inventoryForm).get('company')" />
         </div>
       </app-accordion>
 
       <app-accordion title="Preis">
         <div expansion-panel-content>
           <app-range-slider [minValue]="minAndMaxPrice.minPrice" [maxValue]="minAndMaxPrice.maxPrice"
-                            [controlMin]="$any(inventoryForm).get('minPrice')" [controlMax]="$any(inventoryForm).get('maxPrice')" />
+            [controlMin]="$any(inventoryForm).get('minPrice')" [controlMax]="$any(inventoryForm).get('maxPrice')" />
         </div>
       </app-accordion>
 
       <app-accordion title="Seriennummer">
         <div expansion-panel-content>
           <app-chip-v2 placeholder="Seriennummer hinzufügen" heading="Seriennummer" [options]="serialNumbers"
-                       [control]="$any(inventoryForm).get('serialNumber')" />
+            [control]="$any(inventoryForm).get('serialNumber')" />
         </div>
       </app-accordion>
 
       <app-accordion title="Standort/Nutzer">
         <div expansion-panel-content>
           <app-chip-v2 placeholder="Standort oder Nutzer hinzufügen" heading="Standort/Nutzer" [options]="locations"
-                       [control]="$any(inventoryForm).get('location')" />
+            [control]="$any(inventoryForm).get('location')" />
         </div>
       </app-accordion>
 
       <app-accordion title="Bestellt von">
         <div expansion-panel-content>
           <app-chip-v2 placeholder="Besteller hinzufügen" heading="Besteller" [options]="orderers"
-                       [control]="$any(inventoryForm).get('orderer')" />
+            [control]="$any(inventoryForm).get('orderer')" />
         </div>
       </app-accordion>
 
       <app-accordion title="Tags">
         <div expansion-panel-content>
           <app-chip-v2 placeholder="Tags hinzufügen" heading="Tags" [options]="tags"
-                       [control]="$any(inventoryForm).get('tags')" [useTagColors]="true" />
+            [control]="$any(inventoryForm).get('tags')" [useTagColors]="true" />
         </div>
       </app-accordion>
 
       <app-accordion title="Kostenstelle">
         <div expansion-panel-content>
           <app-chip-v2 placeholder="Kostenstelle hinzufügen" heading="Kostenstellen" [options]="costCenters"
-                       [control]="$any(inventoryForm).get('costCenter')" />
+            [control]="$any(inventoryForm).get('costCenter')" />
         </div>
       </app-accordion>
 
       <app-accordion title="Deinventarisiert">
         <div expansion-panel-content>
           <mat-checkbox label="Deinventarisiert" (click)="checkDeinventoriedBox()"
-                        (keydown)="checkDeinventoriedBox($event)" [checked]="showDeinventoried()">
+            (keydown)="checkDeinventoriedBox($event)" [checked]="showDeinventoried()">
             Deinventarisiertes anzeigen
           </mat-checkbox>
         </div>

--- a/frontend/src/app/pages/inventory/inventory.component.ts
+++ b/frontend/src/app/pages/inventory/inventory.component.ts
@@ -104,6 +104,8 @@ export class InventoryComponent implements OnInit {
    */
   @ViewChildren(AccordionComponent) accordions!: QueryList<AccordionComponent>;
 
+  @ViewChildren(RangeSliderComponent) rangeSliders!: QueryList<RangeSliderComponent>;
+
   /**
    * The form group that contains all the filter controls for the inventory items.
    * It allows the user to filter items based on various criteria (cost center, price, date, etc.).
@@ -192,5 +194,25 @@ export class InventoryComponent implements OnInit {
     }
     this.showDeinventoried.set(!this.showDeinventoried());
     this.inventoryForm.get('isDeinventoried')?.setValue(this.showDeinventoried());
+  }
+
+  resetFilters() {
+    this.showDeinventoried.set(false);
+    this.inventoryForm.reset({
+      costCenter: [],
+      minId: this.minAndMaxId.minId,
+      maxId: this.minAndMaxId.maxId,
+      company: [],
+      minPrice: this.minAndMaxPrice.minPrice,
+      maxPrice: this.minAndMaxPrice.maxPrice,
+      createdAfter: '',
+      createdBefore: '',
+      serialNumber: [],
+      location: [],
+      orderer: [],
+      tags: [],
+      isDeinventoried: this.showDeinventoried(),
+    });
+    this.rangeSliders.forEach(slider => slider.resetSlider());
   }
 }


### PR DESCRIPTION
Introduces a 'Reset' button to the inventory filter UI, which resets all filter form controls and range sliders to their default values. Implements a resetFilters method in InventoryComponent and a resetSlider method in RangeSliderComponent to support this feature.


This pull request introduces enhancements to the `RangeSliderComponent` and `InventoryComponent` to improve functionality and user experience. The most notable changes include the addition of reset functionality for sliders and filters, as well as adjustments to the HTML structure for better layout and usability.

### Enhancements to `RangeSliderComponent`:

* Added a `resetSlider` method to reset the slider values to their minimum and maximum. This ensures the component can easily revert to its initial state.

### Enhancements to `InventoryComponent`:

* Introduced a `resetFilters` method to reset all filter controls to their default values. This method also resets all associated `RangeSliderComponent` instances via the new `resetSlider` method.
* Added a `@ViewChildren` query for `RangeSliderComponent` to facilitate interaction with multiple slider components within the inventory page.

### Improvements to HTML structure:

* Updated the filter action buttons in `inventory.component.html` to include a "Reset" button for clearing filters, and adjusted the layout for better spacing and alignment.

### Code cleanup:

* Reorganized imports in `range-slider.component.ts` for consistency and readability.