### PR TITLE
fix: Initialize search text in inventory list

### DIFF
--- a/frontend/src/app/components/inventory-list/inventory-list.component.ts
+++ b/frontend/src/app/components/inventory-list/inventory-list.component.ts
@@ -128,6 +128,7 @@ export class InventoryListComponent implements AfterViewInit {
 
     // Bind the search bar to the data source
     this.inventoryItems.searchbar = this.searchText;
+    this.searchText.setValue(''); // Initialize search text
   }
 
   /**


### PR DESCRIPTION
Sets the search text value to an empty string during component initialization to ensure the search bar starts cleared. Triggers change detection in ServerTableDataSource.

Problems happened when switching between new extension and inventory list as they use the same component. The ServerTableDataSource didn't update properly.

This pull request introduces a small change to the `InventoryListComponent` in `inventory-list.component.ts`. The change initializes the search text field by setting its value to an empty string.